### PR TITLE
Fix broken Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: objective-c
-osx_image: xcode8.3
+osx_image: xcode9
 sudo: required
 
 env:
   global:
-    - PROJECT="TabNavigatable.xcodeproj"
-    - SCHEME="TabNavigatable"
-    - IOS_SDK="iphonesimulator10.3"
-    - FRAMEWORK="TabNavigatable"
+    - PROJECT="TabNavigable.xcodeproj"
+    - SCHEME="TabNavigable-Package"
+    - IOS_SDK="iphonesimulator11.0"
+    - FRAMEWORK="TabNavigable"
   matrix:
-    - SDK="$IOS_SDK"	DESTINATION="platform=iOS Simulator,name=iPhone 7,OS=10.3.1"
+    - SDK="$IOS_SDK"	DESTINATION="platform=iOS Simulator,name=iPhone 7,OS=11.0"
 
 install:
   - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
@@ -30,5 +30,5 @@ script:
     CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty -c
 
 after_success: 
-  - bash <(curl -s https://codecov.io/bash) -J 'TabNavigatable'
+  - bash <(curl -s https://codecov.io/bash) -J 'TabNavigable'
 


### PR DESCRIPTION
Change `SCHEME` part to `SCHEME="TabNavigable-Package"` because `swift package generate-xcodeproj` command now generate `TabNavigable-Package` scheme in `swift 4`.